### PR TITLE
Changes related to deno 1.4

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        deno-version: [1.2.0]
+        deno-version: [1.4.0]
 
     steps:
       - name: checkout project

--- a/bin/cjs-fix-imports.ts
+++ b/bin/cjs-fix-imports.ts
@@ -1,10 +1,10 @@
-import { parse } from "https://deno.land/std@0.61.0/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.69.0/flags/mod.ts";
 import {
   join,
   resolve,
   basename,
   extname,
-} from "https://deno.land/std@0.61.0/path/mod.ts";
+} from "https://deno.land/std@0.69.0/path/mod.ts";
 
 const argv = parse(
   Deno.args,

--- a/modules/esm/deps.ts
+++ b/modules/esm/deps.ts
@@ -33,7 +33,7 @@ import {
   sign_detached,
   sign_detached_verify,
   randomBytes,
-} from "https://raw.githubusercontent.com/aricart/tweetnacl-deno/v1.0.4/src/nacl.ts";
+} from "https://raw.githubusercontent.com/aricart/tweetnacl-deno/import-type-fixes/src/nacl.ts";
 
 export const denoHelper = {
   fromSeed: sign_keyPair_fromSeed,

--- a/modules/esm/deps.ts
+++ b/modules/esm/deps.ts
@@ -26,7 +26,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 //
 //   For more information, please refer to <http://unlicense.org>
-import { Ed25519Helper } from "../../src/helper.ts";
+import type { Ed25519Helper } from "../../src/helper.ts";
 
 import {
   sign_keyPair_fromSeed,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nkeys.js",
-  "version": "1.0.0-5",
+  "version": "1.0.0-6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nkeys.js",
-  "version": "1.0.0-6",
+  "version": "1.0.0-7",
   "description": "A public-key signature system based on Ed25519 for the NATS ecosystem in javascript",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -12,6 +12,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export type {
+  KeyPair,
+} from "./nkeys.ts";
 export {
   createPair,
   createAccount,
@@ -19,9 +22,8 @@ export {
   createOperator,
   fromPublic,
   fromSeed,
-  KeyPair,
   NKeysError,
-  NKeysErrorCode,
+  NKeysErrorCode
 } from "./nkeys.ts";
 
 export {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -23,7 +23,7 @@ export {
   fromPublic,
   fromSeed,
   NKeysError,
-  NKeysErrorCode
+  NKeysErrorCode,
 } from "./nkeys.ts";
 
 export {

--- a/test/base32_test.ts
+++ b/test/base32_test.ts
@@ -16,7 +16,7 @@
 import { base32 } from "../src/base32.ts";
 import {
   assertEquals,
-} from "https://deno.land/std@0.61.0/testing/asserts.ts";
+} from "https://deno.land/std@0.69.0/testing/asserts.ts";
 
 function assertEqualUint8Arrays(a: Uint8Array, b: Uint8Array) {
   assertEquals(a.length, b.length);

--- a/test/basics_test.ts
+++ b/test/basics_test.ts
@@ -16,7 +16,7 @@
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std@0.61.0/testing/asserts.ts";
+} from "https://deno.land/std@0.69.0/testing/asserts.ts";
 import {
   createAccount,
   createOperator,

--- a/test/codec_test.ts
+++ b/test/codec_test.ts
@@ -16,7 +16,7 @@ import { assertThrowsErrorCode } from "./util.ts";
 
 import {
   assertEquals,
-} from "https://deno.land/std@0.61.0/testing/asserts.ts";
+} from "https://deno.land/std@0.69.0/testing/asserts.ts";
 import { Codec } from "../src/codec.ts";
 import { NKeysErrorCode, Prefix } from "../src/nkeys.ts";
 

--- a/test/crc16_test.ts
+++ b/test/crc16_test.ts
@@ -17,7 +17,7 @@ import { crc16 } from "../src/crc16.ts";
 import {
   assertEquals,
   assert,
-} from "https://deno.land/std@0.61.0/testing/asserts.ts";
+} from "https://deno.land/std@0.69.0/testing/asserts.ts";
 
 Deno.test("crc16 - should return [0xC8, 0xB2] given [0x41, 0x4C, 0x42, 0x45, 0x52, 0x54, 0x4F]", () => {
   const buf = new Uint8Array([0x41, 0x4C, 0x42, 0x45, 0x52, 0x54, 0x4F]);

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -15,7 +15,7 @@
 import {
   assertEquals,
   assert,
-} from "https://deno.land/std@0.61.0/testing/asserts.ts";
+} from "https://deno.land/std@0.69.0/testing/asserts.ts";
 
 import {
   fromPublic,

--- a/test/util.ts
+++ b/test/util.ts
@@ -16,7 +16,7 @@
 import {
   assert,
   fail,
-} from "https://deno.land/std@0.61.0/testing/asserts.ts";
+} from "https://deno.land/std@0.69.0/testing/asserts.ts";
 
 export function assertThrowsErrorCode(fn: () => any, ...codes: string[]) {
   try {


### PR DESCRIPTION
- Updated CI to use 1.4
- Updated uses of std to 0.69.0
- Pacified tsc compiler regarding type imports that are propagated down. (`import type`)