### PR TITLE
[fix] exported `Prefix`

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        deno-version: [1.4.0]
+        deno-version: [1.4.6]
 
     steps:
       - name: checkout project

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        deno-version: [1.2.0]
+        deno-version: [1.4.6]
         node-version: [10.x, 14.x]
 
     steps:

--- a/bin/cjs-fix-imports.ts
+++ b/bin/cjs-fix-imports.ts
@@ -1,10 +1,10 @@
-import { parse } from "https://deno.land/std@0.69.0/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.75.0/flags/mod.ts";
 import {
   join,
   resolve,
   basename,
   extname,
-} from "https://deno.land/std@0.69.0/path/mod.ts";
+} from "https://deno.land/std@0.75.0/path/mod.ts";
 
 const argv = parse(
   Deno.args,

--- a/examples/basics.ts
+++ b/examples/basics.ts
@@ -1,8 +1,4 @@
-import {
-  createUser,
-  fromPublic,
-  fromSeed,
-} from "../src/mod.ts";
+import { createUser, fromPublic, fromSeed } from "../src/mod.ts";
 
 // create an user nkey KeyPair (can also create accounts, operators, etc).
 const user = createUser();

--- a/modules/esm/deps.ts
+++ b/modules/esm/deps.ts
@@ -29,10 +29,10 @@
 import type { Ed25519Helper } from "../../src/helper.ts";
 
 import {
-  sign_keyPair_fromSeed,
+  randomBytes,
   sign_detached,
   sign_detached_verify,
-  randomBytes,
+  sign_keyPair_fromSeed,
 } from "https://raw.githubusercontent.com/aricart/tweetnacl-deno/import-type-fixes/src/nacl.ts";
 
 export const denoHelper = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nkeys.js",
-  "version": "1.0.0-7",
+  "version": "1.0.0-8",
   "description": "A public-key signature system based on Ed25519 for the NATS ecosystem in javascript",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -11,7 +11,7 @@
     "cjs": "deno run --allow-all bin/cjs-fix-imports.ts -o build/ src/ modules/cjs/ node_test/",
     "stage": "npm run init && npm run cjs && tsc",
     "prepare": "npm run stage && deno bundle modules/esm/mod.ts nkeys.mjs && tsc",
-    "test": "npm run prepare && ava --verbose",
+    "test": "npm run prepare && ava --verbose && deno test test/",
     "doc": "node_modules/.bin/typedoc --options ./typedoc.json && touch ./docs/.nojekyll"
   },
   "engines": {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -12,21 +12,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export type {
-  KeyPair,
-} from "./nkeys.ts";
+export type { KeyPair } from "./nkeys.ts";
 export {
-  createPair,
   createAccount,
-  createUser,
   createOperator,
+  createPair,
+  createUser,
   fromPublic,
   fromSeed,
   NKeysError,
   NKeysErrorCode,
+  Prefix,
 } from "./nkeys.ts";
 
-export {
-  encode,
-  decode,
-} from "./util.ts";
+export { decode, encode } from "./util.ts";

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,9 +22,9 @@ export function encode(bytes: Uint8Array): string {
 
 /**
  * Decode a base64 encoded string to a binary Uint8Array
- * @param {string} base64 encoded string
+ * @param {string} b64str encoded string
  */
-export function decode(b64str: string) {
+export function decode(b64str: string): Uint8Array {
   const bin = atob(b64str);
   const bytes = new Uint8Array(bin.length);
   for (let i = 0; i < bin.length; i++) {

--- a/test/base32_test.ts
+++ b/test/base32_test.ts
@@ -14,9 +14,7 @@
  */
 
 import { base32 } from "../src/base32.ts";
-import {
-  assertEquals,
-} from "https://deno.land/std@0.69.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.75.0/testing/asserts.ts";
 
 function assertEqualUint8Arrays(a: Uint8Array, b: Uint8Array) {
   assertEquals(a.length, b.length);

--- a/test/basics_test.ts
+++ b/test/basics_test.ts
@@ -16,7 +16,7 @@
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std@0.69.0/testing/asserts.ts";
+} from "https://deno.land/std@0.75.0/testing/asserts.ts";
 import {
   createAccount,
   createOperator,
@@ -27,12 +27,7 @@ import {
   KeyPair,
   NKeysErrorCode,
 } from "../modules/esm/mod.ts";
-import {
-  createCluster,
-  createServer,
-  Prefix,
-  Prefixes,
-} from "../src/nkeys.ts";
+import { createCluster, createServer, Prefix, Prefixes } from "../src/nkeys.ts";
 import { KP } from "../src/kp.ts";
 import { Codec } from "../src/codec.ts";
 import { assertThrowsErrorCode } from "./util.ts";

--- a/test/codec_test.ts
+++ b/test/codec_test.ts
@@ -14,9 +14,7 @@
  */
 import { assertThrowsErrorCode } from "./util.ts";
 
-import {
-  assertEquals,
-} from "https://deno.land/std@0.69.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.75.0/testing/asserts.ts";
 import { Codec } from "../src/codec.ts";
 import { NKeysErrorCode, Prefix } from "../src/nkeys.ts";
 

--- a/test/crc16_test.ts
+++ b/test/crc16_test.ts
@@ -15,9 +15,9 @@
 
 import { crc16 } from "../src/crc16.ts";
 import {
-  assertEquals,
   assert,
-} from "https://deno.land/std@0.69.0/testing/asserts.ts";
+  assertEquals,
+} from "https://deno.land/std@0.75.0/testing/asserts.ts";
 
 Deno.test("crc16 - should return [0xC8, 0xB2] given [0x41, 0x4C, 0x42, 0x45, 0x52, 0x54, 0x4F]", () => {
   const buf = new Uint8Array([0x41, 0x4C, 0x42, 0x45, 0x52, 0x54, 0x4F]);

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -13,16 +13,11 @@
  * limitations under the License.
  */
 import {
-  assertEquals,
   assert,
-} from "https://deno.land/std@0.69.0/testing/asserts.ts";
+  assertEquals,
+} from "https://deno.land/std@0.75.0/testing/asserts.ts";
 
-import {
-  fromPublic,
-  fromSeed,
-  encode,
-  decode,
-} from "../modules/esm/mod.ts";
+import { decode, encode, fromPublic, fromSeed } from "../modules/esm/mod.ts";
 
 import { Codec } from "../src/codec.ts";
 import { Prefix } from "../src/nkeys.ts";

--- a/test/util.ts
+++ b/test/util.ts
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 
-import {
-  assert,
-  fail,
-} from "https://deno.land/std@0.69.0/testing/asserts.ts";
+import { assert, fail } from "https://deno.land/std@0.75.0/testing/asserts.ts";
 
 export function assertThrowsErrorCode(fn: () => any, ...codes: string[]) {
   try {


### PR DESCRIPTION
- [fix] exported `Prefix` - FIX #4
- [update] updated to deno 1.4.6 and std 0.75.0 (adopted current code formatting)