### PR TITLE
[FIX] nacl should not be undefined when module.exports is defined

### DIFF
--- a/modules/esm/nacl.js
+++ b/modules/esm/nacl.js
@@ -1183,4 +1183,4 @@ nacl.setPRNG = function(fn) {
 })(typeof module !== 'undefined' && module.exports ? module.exports : (globalThis.nacl = globalThis.nacl || {}));
 
 //added by nkeys.js export it
-export const nacl = globalThis.nacl;
+export const nacl = typeof module !== 'undefined' && module.exports ? module.exports : globalThis.nacl;


### PR DESCRIPTION
Context:
```javascript
(function(nacl) {
... // Jump to the end of the function
})(typeof module !== 'undefined' && module.exports ? module.exports : globalThis.nacl = globalThis.nacl || {});
const nacl = globalThis.nacl;
```
Reviewing the ternary clause (above) that determines what to pass as `nacl` to the function: if `module.exports` is defined, `nacl` will be written into `module.exports` and `globalThis.nacl` won't be reached in the ternary else clause where it would have been defined. So nacl becomes undefined when `module.exports` is defined via the the next statement (show above but copied here for clarity): 
```javascript
const nacl = globalThis.nacl;
```
And the first attempt to work with nacl in the derived websocket projects (nats.ws) results in `.sign` going against the undefined nacl object:
```javascript
const nacl = globalThis.nacl; // globalThis.nacl isn't defined when module.exports is defined
const denoHelper = {
    fromSeed: nacl.sign.keyPair.fromSeed, // nacl is undefined because it was written into module.exports, not globalThis.nacl
    sign: nacl.sign.detached,
    verify: nacl.sign.detached.verify,
    randomBytes: nacl.randomBytes
};
```
This PR makes the nacl assignment mirror the ternary condition, yielding:
```javascript
const nacl = typeof module !== 'undefined' && module.exports ? module.exports : globalThis.nacl;
```


See my [comment](https://github.com/nats-io/nats.ws/issues/168#issuecomment-1352313650) on the related nats.ws issue for additional context.