### PR TITLE
Import Prefix direct from provider nkeys.ts instead of mod.ts

### DIFF
--- a/src/curve.ts
+++ b/src/curve.ts
@@ -16,7 +16,7 @@
 import { KeyPair, NKeysError, NKeysErrorCode } from "./nkeys.ts";
 import { getEd25519Helper } from "./helper.ts";
 import { Codec } from "./codec.ts";
-import { Prefix } from "./mod.ts";
+import { Prefix } from "./nkeys.ts";
 import { base32 } from "./base32.ts";
 import { crc16 } from "./crc16.ts";
 


### PR DESCRIPTION
The file `curve.ts` imports `Prefix`  from `mod.ts`, which imports it from `nkeys.ts`.  This PR changes the import to go directly to `nkeys.ts`.

### Background:

I am working on a project to get the client to work on a platform called [`Moddable`](https://github.com/moddable-opensource/moddable), a modern JS engine (called `XS`) that targets microcontrollers.  Because it pre-compiles the source and does not have an actual file system on the device for the files it uses a unique module resolution system that can be tricky sometimes to work with.  In this case, because `mod.ts` was being imported in a secondary file, and `mod.ts` is the main entry point, it is unable to resolve the import.  This PR resolves that issue.