### PR TITLE
Update versions and dependencies

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        deno-version: [2.1.x]
+        deno-version: [2.5.x]
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,8 +16,8 @@ jobs:
 
     strategy:
       matrix:
-        deno-version: [2.1.x]
-        node-version: [22.x]
+        deno-version: [2.5.x]
+        node-version: [24.x]
 
     steps:
       - name: checkout nkeys

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -8,8 +8,8 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [22.x]
-        deno-version: [2.1.x]
+        node-version: [24.x]
+        deno-version: [2.5.x]
 
     runs-on: ubuntu-latest
     permissions:

--- a/deno.json
+++ b/deno.json
@@ -31,7 +31,8 @@
     "exclude": ["lib/", "build/", "docs/"]
   },
   "imports": {
+    "@std/assert": "jsr:@std/assert@^1.0.14",
     "tweetnacl": "npm:tweetnacl@1.0.3"
   },
-  "nodeModulesDir": "auto"
+  "nodeModulesDir": true
 }

--- a/dependencies.md
+++ b/dependencies.md
@@ -2,11 +2,11 @@
 
 This file lists the dependencies used in this repository.
 
-| Dependency                           | License     |
-| ------------------------------------ | ----------- |
-| tweetnacl                            | Unilicense  |
-| CI and build dependencies            |             |
-| https://github.com/denoland/deno_std | MIT License |
-| typedoc                              | Apache-2.0  |
-| typescript                           | Apache-2.0  |
-| @types/node                          | MIT         |
+| Dependency          | License    |
+| ------------------- | ---------- |
+| tweetnacl           | Unlicense  |
+| Dev Dependencies    |            |
+| @std/assert@^1.0.14 | MIT        |
+| typedoc             | Apache-2.0 |
+| typescript          | Apache-2.0 |
+| @types/node         | MIT        |

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,40 +13,62 @@
       },
       "devDependencies": {
         "@types/node": "^22.13.10",
-        "typedoc": "^0.28.1",
-        "typescript": "^5.8.2"
+        "typedoc": "^0.28.12",
+        "typescript": "^5.8.3"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.1.tgz",
-      "integrity": "sha512-HbzRC6MKB6U8kQhczz0APKPIzFHTrcqhaC7es2EXInq1SpjPVnpVSIsBe6hNoLWqqCx1n5VKiPXq6PfXnHZKOQ==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.12.2.tgz",
+      "integrity": "sha512-HKZPmO8OSSAAo20H2B3xgJdxZaLTwtlMwxg0967scnrDlPwe6j5+ULGHyIqwgTbFCn9yv/ff8CmfWZLE9YKBzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-oniguruma": "^3.2.1",
-        "@shikijs/types": "^3.2.1",
+        "@shikijs/engine-oniguruma": "^3.12.2",
+        "@shikijs/langs": "^3.12.2",
+        "@shikijs/themes": "^3.12.2",
+        "@shikijs/types": "^3.12.2",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.1.tgz",
-      "integrity": "sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.12.2.tgz",
+      "integrity": "sha512-hozwnFHsLvujK4/CPVHNo3Bcg2EsnG8krI/ZQ2FlBlCRpPZW4XAEQmEwqegJsypsTAN9ehu2tEYe30lYKSZW/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.2.1",
+        "@shikijs/types": "3.12.2",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
+    "node_modules/@shikijs/langs": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.12.2.tgz",
+      "integrity": "sha512-bVx5PfuZHDSHoBal+KzJZGheFuyH4qwwcwG/n+MsWno5cTlKmaNtTsGzJpHYQ8YPbB5BdEdKU1rga5/6JGY8ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.12.2"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.12.2.tgz",
+      "integrity": "sha512-fTR3QAgnwYpfGczpIbzPjlRnxyONJOerguQv1iwpyQZ9QXX4qy/XFQqXlf17XTsorxnHoJGbH/LXBvwtqDsF5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.12.2"
+      }
+    },
     "node_modules/@shikijs/types": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.1.tgz",
-      "integrity": "sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.12.2.tgz",
+      "integrity": "sha512-K5UIBzxCyv0YoxN3LMrKB9zuhp1bV+LgewxuVwHdl4Gz5oePoUFrr9EfgJlGlDeXCU1b/yhdnXeuRvAnz8HN8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -102,9 +124,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -193,17 +215,17 @@
       "license": "Unlicense"
     },
     "node_modules/typedoc": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.1.tgz",
-      "integrity": "sha512-Mn2VPNMaxoe/hlBiLriG4U55oyAa3Xo+8HbtEwV7F5WEOPXqtxzGuMZhJYHaqFJpajeQ6ZDUC2c990NAtTbdgw==",
+      "version": "0.28.12",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.12.tgz",
+      "integrity": "sha512-H5ODu4f7N+myG4MfuSp2Vh6wV+WLoZaEYxKPt2y8hmmqNEMVrH69DAjjdmYivF4tP/C2jrIZCZhPalZlTU/ipA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gerrit0/mini-shiki": "^3.2.1",
+        "@gerrit0/mini-shiki": "^3.12.0",
         "lunr": "^2.3.9",
         "markdown-it": "^14.1.0",
         "minimatch": "^9.0.5",
-        "yaml": "^2.7.0 "
+        "yaml": "^2.8.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -213,13 +235,13 @@
         "pnpm": ">= 10"
       },
       "peerDependencies": {
-        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -244,16 +266,16 @@
       "license": "MIT"
     },
     "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.13.10",
-    "typedoc": "^0.28.1",
-    "typescript": "^5.8.2"
+    "typedoc": "^0.28.12",
+    "typescript": "^5.8.3"
   }
 }

--- a/test/base32_test.ts
+++ b/test/base32_test.ts
@@ -14,7 +14,7 @@
  */
 
 import { base32 } from "../src/base32.ts";
-import { assertEquals } from "https://deno.land/std@0.75.0/testing/asserts.ts";
+import { assertEquals } from "@std/assert";
 
 function assertEqualUint8Arrays(a: Uint8Array, b: Uint8Array) {
   assertEquals(a.length, b.length);

--- a/test/basics_test.ts
+++ b/test/basics_test.ts
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 //
-import {
-  assert,
-  assertEquals,
-} from "https://deno.land/std@0.75.0/testing/asserts.ts";
+import { assert, assertEquals } from "@std/assert";
 import {
   createAccount,
   createOperator,

--- a/test/codec_test.ts
+++ b/test/codec_test.ts
@@ -14,7 +14,7 @@
  */
 import { assertThrowsErrorCode } from "./util.ts";
 
-import { assertEquals } from "https://deno.land/std@0.75.0/testing/asserts.ts";
+import { assertEquals } from "@std/assert";
 import { Codec } from "../src/codec.ts";
 import { NKeysErrorCode, Prefix } from "../src/nkeys.ts";
 

--- a/test/crc16_test.ts
+++ b/test/crc16_test.ts
@@ -14,10 +14,7 @@
  */
 
 import { crc16 } from "../src/crc16.ts";
-import {
-  assert,
-  assertEquals,
-} from "https://deno.land/std@0.75.0/testing/asserts.ts";
+import { assert, assertEquals } from "@std/assert";
 
 Deno.test("crc16 - should return [0xC8, 0xB2] given [0x41, 0x4C, 0x42, 0x45, 0x52, 0x54, 0x4F]", () => {
   const buf = new Uint8Array([0x41, 0x4C, 0x42, 0x45, 0x52, 0x54, 0x4F]);

--- a/test/curve_test.ts
+++ b/test/curve_test.ts
@@ -19,10 +19,7 @@ import {
   fromSeed,
   NKeysErrorCode,
 } from "../src/mod.ts";
-import {
-  assert,
-  assertEquals,
-} from "https://deno.land/std@0.200.0/assert/mod.ts";
+import { assert, assertEquals } from "@std/assert";
 import { assertThrowsErrorCode } from "./util.ts";
 import type { CurveKP } from "../src/curve.ts";
 import { createAccount } from "../src/nkeys.ts";

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -12,10 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  assert,
-  assertEquals,
-} from "https://deno.land/std@0.75.0/testing/asserts.ts";
+import { assert, assertEquals } from "@std/assert";
 
 import { decode, encode, fromPublic, fromSeed } from "../src/mod.ts";
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { assert, fail } from "https://deno.land/std@0.75.0/testing/asserts.ts";
+import { assert, fail } from "@std/assert";
 
 export function assertThrowsErrorCode(fn: () => unknown, ...codes: string[]) {
   try {


### PR DESCRIPTION
Upgraded `deno.json` to use Deno `2.5.x`, updated development dependencies (`@types/node`, `typedoc`, `typescript`), and switched to `@std/assert` for testing. Revised CI matrix configurations and refreshed dependency metadata for consistency. Imports on test changed to reference deps in deno.json as per deno linter.


Signed-off-by: alberto@synadia.io
